### PR TITLE
[WIP] Add: Background blur effect to delete confirmation modal

### DIFF
--- a/app/assets/javascripts/delete-confirmation-modal.js
+++ b/app/assets/javascripts/delete-confirmation-modal.js
@@ -1,3 +1,6 @@
+var timeMillisecs = 500;
+var timeSecs = timeMillisecs / 1000;
+
 $.rails.allowAction = function(link) {
   if (!link.attr('data-confirm')) {
     return true;
@@ -16,8 +19,8 @@ $.rails.showConfirmDialog = function(link) {
 
   $('<div class="overlay"></div>')
     .css('top', $(document).scrollTop())
-    .css('opacity', '0')
-    .animate({'opacity': '0.5'}, 'slow')
+    .css('opacity', 0.5)
+    .fadeIn(timeMillisecs)
     .appendTo('body');
 
   var model = link.attr('data-model');
@@ -32,7 +35,9 @@ $.rails.showConfirmDialog = function(link) {
         'top': top + $(document).scrollTop(),
         'left': left
       })
-      .fadeIn();
+      .fadeIn(timeMillisecs);
+
+      blurElement($('.modal').siblings(), 2);
 
     $('.confirm').click(function() {
       $.rails.confirmed(link);
@@ -42,6 +47,27 @@ $.rails.showConfirmDialog = function(link) {
       removeModal();
     });
 };
+
+function blurElement(element, blurSize) {
+  var filterVal = 'blur(' + blurSize + 'px)';
+  $(element)
+    .css('filter', filterVal)
+    .css('webkitFilter', filterVal)
+    .css('mozFilter', filterVal)
+    .css('oFilter', filterVal)
+    .css('msFilter', filterVal)
+    transition(element, 'ease-out');
+}
+
+function transition(element, effect) {
+  var transitionVal = 'all ' + timeSecs + 's ' + effect
+  $(element)
+    .css('transition', transitionVal)
+    .css('-webkit-transition', transitionVal)
+    .css('-moz-transition', transitionVal)
+    .css('-o-transition', transitionVal)
+    .css('-ms-transition', transitionVal);
+}
 
 $(document).mouseup(function (e)
 {
@@ -53,8 +79,10 @@ $(document).mouseup(function (e)
 });
 
 function removeModal() {
+  blurElement($('.modal').siblings(), 0, timeSecs);
+
   $('.overlay, .modal')
-    .fadeOut('slow', function() {
+    .fadeOut(timeMillisecs, function() {
       $(this).remove();
       $('body').css('overflow-y', 'auto');
     });


### PR DESCRIPTION
- [ ] Modal seems to fade out faster than overlay, causing jolt at end of animation of the latter (owing to it being removed). Prevented if modal fade-out a callback following overlay fade-out, so perhaps an examination of that will show cause; perhaps forced delay before removing elements?
