### PR TITLE
Amend: current_path testing method in feature tests

### DIFF
--- a/spec/features/productions/productions_delete_spec.rb
+++ b/spec/features/productions/productions_delete_spec.rb
@@ -20,7 +20,7 @@ feature 'Production delete' do
       expect(page).to have_css '.alert-success'
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_content production.title, count: 2
-      expect(current_path).to eq productions_path
+      expect(page).to have_current_path productions_path
     end
   end
 end

--- a/spec/features/productions/productions_edit_update_spec.rb
+++ b/spec/features/productions/productions_edit_update_spec.rb
@@ -29,7 +29,7 @@ feature 'Production edit/update' do
       expect(page).not_to have_css '.field_with_errors'
       expect(page).to have_content 'Macbeth', count: 2
       expect(page).not_to have_content production.title
-      expect(current_path).to eq production_path(production)
+      expect(page).to have_current_path production_path(production)
       expect(production.reload.creator).to eq(second_user)
       expect(production.updater).to eq(user)
       expect(second_user.created_productions).to include(production)
@@ -53,7 +53,7 @@ feature 'Production edit/update' do
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
       expect(page).to have_content production.title
-      expect(current_path).to eq production_path(production)
+      expect(page).to have_current_path production_path(production)
       expect(production.reload.creator).to eq(second_user)
       expect(production.updater).to eq(second_user)
       expect(second_user.created_productions).to include(production)

--- a/spec/features/productions/productions_new_create_spec.rb
+++ b/spec/features/productions/productions_new_create_spec.rb
@@ -26,7 +26,7 @@ feature 'Production new/create' do
       expect(page).not_to have_css '.field_with_errors'
       expect(page).to have_content 'Hamlet', count: 2
       @production = Production.last
-      expect(current_path).to eq production_path(@production)
+      expect(page).to have_current_path production_path(@production)
       expect(@production.creator).to eq(user)
       expect(@production.updater).to eq(user)
       expect(user.created_productions).to include(@production)
@@ -46,7 +46,7 @@ feature 'Production new/create' do
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
       expect(page).to have_content 'New production'
-      expect(current_path).to eq productions_path
+      expect(page).to have_current_path productions_path
     end
   end
 end

--- a/spec/features/productions/productions_show_spec.rb
+++ b/spec/features/productions/productions_show_spec.rb
@@ -15,7 +15,7 @@ feature 'Production show page' do
       visit productions_path
       click_link production.title
       expect(page).to have_content production.title
-      expect(current_path).to eq production_path(production)
+      expect(page).to have_current_path production_path(production)
     end
   end
 

--- a/spec/features/users/users_admin_status_spec.rb
+++ b/spec/features/users/users_admin_status_spec.rb
@@ -10,23 +10,23 @@ feature 'User edit/update admin status' do
     scenario 'attempt edit self (super-admin user): fail and redirect to home page', js: true do
       visit edit_admin_status_path(super_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit another super-admin user: fail and redirect to home page', js: true do
       visit edit_admin_status_path(second_super_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit admin user: render admin user admin status edit form', js: true do
       visit edit_admin_status_path(admin_user)
-      expect(current_path).to eq edit_admin_status_path(admin_user)
+      expect(page).to have_current_path edit_admin_status_path(admin_user)
     end
 
     scenario 'attempt edit non-admin user: render non-admin user admin status edit form', js: true do
       visit edit_admin_status_path(user)
-      expect(current_path).to eq edit_admin_status_path(user)
+      expect(page).to have_current_path edit_admin_status_path(user)
     end
   end
 
@@ -39,25 +39,25 @@ feature 'User edit/update admin status' do
     scenario 'attempt edit super-admin user: fail and redirect to home page', js: true do
       visit edit_admin_status_path(super_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit self (admin user): fail and redirect to home page', js: true do
       visit edit_admin_status_path(admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit another admin user: fail and redirect to home page', js: true do
       visit edit_admin_status_path(second_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit non-admin user: fail and redirect to home page', js: true do
       visit edit_admin_status_path(user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -70,25 +70,25 @@ feature 'User edit/update admin status' do
     scenario 'attempt edit super-admin user: fail and redirect to home page', js: true do
       visit edit_admin_status_path(super_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit admin user: fail and redirect to home page', js: true do
       visit edit_admin_status_path(admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit self (non-admin user): fail and redirect to home page', js: true do
       visit edit_admin_status_path(user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit another non-admin user: fail and redirect to home page', js: true do
       visit edit_admin_status_path(second_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -98,7 +98,7 @@ feature 'User edit/update admin status' do
     scenario 'fail and redirect to log in page', js: true do
       visit edit_admin_status_path(user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq log_in_path
+      expect(page).to have_current_path log_in_path
     end
   end
 
@@ -109,7 +109,7 @@ feature 'User edit/update admin status' do
     scenario 'click on \'Edit Admin Status\' button on user profile page; display user edit form' do
       visit user_path(user)
       click_button 'Edit Admin Status'
-      expect(current_path).to eq edit_admin_status_path(user)
+      expect(page).to have_current_path edit_admin_status_path(user)
     end
   end
 
@@ -128,7 +128,7 @@ feature 'User edit/update admin status' do
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_css '.field_with_errors'
       expect(user.admin).to be nil
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
       visit edit_admin_status_path(user)
       check('status')
       click_button 'Update Admin Status'
@@ -136,7 +136,7 @@ feature 'User edit/update admin status' do
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_css '.field_with_errors'
       expect(user.reload.admin).not_to be nil
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
       visit edit_admin_status_path(user)
       uncheck('status')
       click_button 'Update Admin Status'
@@ -144,7 +144,7 @@ feature 'User edit/update admin status' do
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_css '.field_with_errors'
       expect(user.reload.admin).to be nil
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
 
     scenario 'assignor and assignee associations created/destroyed', js: true do
@@ -170,7 +170,7 @@ feature 'User edit/update admin status' do
       expect(page).to have_button('Delete User')
       expect(page).not_to have_button('Edit Admin Status')
       expect(page).not_to have_button('Edit User')
-      expect(current_path).to eq user_path(second_user)
+      expect(page).to have_current_path user_path(second_user)
       click_link 'Log out'
       log_in super_admin_user
       visit edit_admin_status_path(user)
@@ -180,7 +180,7 @@ feature 'User edit/update admin status' do
       log_in user
       visit user_path(second_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 end

--- a/spec/features/users/users_delete_spec.rb
+++ b/spec/features/users/users_delete_spec.rb
@@ -17,7 +17,7 @@ feature 'User delete' do
       expect(page).to have_css '.alert-success'
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_link(user.name, href: user_path(admin_user))
-      expect(current_path).to eq users_path
+      expect(page).to have_current_path users_path
     end
 
     scenario 'delete non-admin user; redirect to user index with success message', js: true do
@@ -28,7 +28,7 @@ feature 'User delete' do
       expect(page).to have_css '.alert-success'
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_link(user.name, href: user_path(user))
-      expect(current_path).to eq users_path
+      expect(page).to have_current_path users_path
     end
   end
 
@@ -50,7 +50,7 @@ feature 'User delete' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile', href: user_path(admin_user))
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'delete non-admin user; redirect to user index with success message', js: true do
@@ -61,7 +61,7 @@ feature 'User delete' do
       expect(page).to have_css '.alert-success'
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_link(user.name, href: user_path(user))
-      expect(current_path).to eq users_path
+      expect(page).to have_current_path users_path
     end
   end
 
@@ -79,7 +79,7 @@ feature 'User delete' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile', href: user_path(user))
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -92,7 +92,7 @@ feature 'User delete' do
       expect { click_button 'Cancel' }.to change { User.count }.by 0
       expect(User.exists? user.id).to be true
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
   end
 end

--- a/spec/features/users/users_edit_update_spec.rb
+++ b/spec/features/users/users_edit_update_spec.rb
@@ -9,25 +9,25 @@ feature 'User edit/update' do
 
     scenario 'attempt edit self (super-admin user): render super-admin user edit form', js: true do
       visit edit_user_path(super_admin_user)
-      expect(current_path).to eq edit_user_path(super_admin_user)
+      expect(page).to have_current_path edit_user_path(super_admin_user)
     end
 
     scenario 'attempt edit another super-admin user: fail and redirect to home page', js: true do
       visit edit_user_path(second_super_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit admin user: fail and redirect to home page', js: true do
       visit edit_user_path(admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit non-admin user: fail and redirect to home page', js: true do
       visit edit_user_path(user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -40,24 +40,24 @@ feature 'User edit/update' do
     scenario 'attempt edit super-admin user: fail and redirect to home page', js: true do
       visit edit_user_path(super_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit self (admin user): render admin user edit form', js: true do
       visit edit_user_path(admin_user)
-      expect(current_path).to eq edit_user_path(admin_user)
+      expect(page).to have_current_path edit_user_path(admin_user)
     end
 
     scenario 'attempt edit another admin user: fail and redirect to home page', js: true do
       visit edit_user_path(second_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit non-admin user: fail and redirect to home page', js: true do
       visit edit_user_path(user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -70,24 +70,24 @@ feature 'User edit/update' do
     scenario 'attempt edit super-admin user: fail and redirect to home page', js: true do
       visit edit_user_path(super_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit admin user: fail and redirect to home page', js: true do
       visit edit_user_path(admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit self (non-admin user): render non-admin user edit form', js: true do
       visit edit_user_path(user)
-      expect(current_path).to eq edit_user_path(user)
+      expect(page).to have_current_path edit_user_path(user)
     end
 
     scenario 'attempt edit another non-admin user: fail and redirect to home page', js: true do
       visit edit_user_path(second_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -97,7 +97,7 @@ feature 'User edit/update' do
     scenario 'fail and redirect to log in page', js: true do
       visit edit_user_path(user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq log_in_path
+      expect(page).to have_current_path log_in_path
     end
   end
 
@@ -107,7 +107,7 @@ feature 'User edit/update' do
     scenario 'click on \'Edit User\' button on user profile page; display user edit form' do
       visit user_path(user)
       click_button 'Edit User'
-      expect(current_path).to eq edit_user_path(user)
+      expect(page).to have_current_path edit_user_path(user)
     end
   end
 
@@ -129,7 +129,7 @@ feature 'User edit/update' do
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_css '.field_with_errors'
       expect(page).to have_content(edit_user[:name])
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
 
     scenario 'valid details; existing creator association remains and updater association (w/itself) updated', js: true do
@@ -157,7 +157,7 @@ feature 'User edit/update' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile')
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq log_in_path
+      expect(page).to have_current_path log_in_path
       fill_in 'session_email',    with: edit_user[:email]
       fill_in 'session_password', with: edit_user[:password]
       click_button 'Log In'
@@ -166,7 +166,7 @@ feature 'User edit/update' do
       expect(page).to have_link('Profile', href: user_path(user))
       expect(page).to have_link('Log out', href: log_out_path)
       expect(page).not_to have_link('Log in', href: log_in_path)
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
 
     scenario 'valid details (retaining existing password); redirect to user profile with success message', js: true do
@@ -178,7 +178,7 @@ feature 'User edit/update' do
       expect(page).to have_css '.alert-success'
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_css '.field_with_errors'
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
 
     scenario 'if existing password is retained it can still be used', js: true do
@@ -197,7 +197,7 @@ feature 'User edit/update' do
       expect(page).to have_link('Profile', href: user_path(user))
       expect(page).to have_link('Log out', href: log_out_path)
       expect(page).not_to have_link('Log in', href: log_in_path)
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
   end
 
@@ -220,7 +220,7 @@ feature 'User edit/update' do
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
       expect(page).to have_content user.name
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
 
     scenario 'invalid name', js: true do
@@ -232,7 +232,7 @@ feature 'User edit/update' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
 
     scenario 'invalid email', js: true do
@@ -244,7 +244,7 @@ feature 'User edit/update' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
 
     scenario 'password as single whitespace (with no confirmation)', js: true do
@@ -256,7 +256,7 @@ feature 'User edit/update' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
 
     scenario 'password and confirmation too short', js: true do
@@ -268,7 +268,7 @@ feature 'User edit/update' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
 
     scenario 'non-matching password and confirmation', js: true do
@@ -280,7 +280,7 @@ feature 'User edit/update' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
 
     scenario 'invalid details; existing creator and updater associations remain', js: true do

--- a/spec/features/users/users_index_spec.rb
+++ b/spec/features/users/users_index_spec.rb
@@ -53,7 +53,7 @@ feature 'User index page' do
     scenario 'redirect to home page', js: true do
       visit users_path
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -61,7 +61,7 @@ feature 'User index page' do
     scenario 'redirect to log in page', js: true do
       visit users_path
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq log_in_path
+      expect(page).to have_current_path log_in_path
     end
   end
 end

--- a/spec/features/users/users_log_in_spec.rb
+++ b/spec/features/users/users_log_in_spec.rb
@@ -16,7 +16,7 @@ feature 'User log in' do
       expect(page).to have_link('Profile', href: user_path(user))
       expect(page).to have_link('Log out', href: log_out_path)
       expect(page).not_to have_link('Log in', href: log_in_path)
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
   end
 
@@ -34,7 +34,7 @@ feature 'User log in' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile')
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq log_in_path
+      expect(page).to have_current_path log_in_path
     end
 
     scenario 'correct email address but incorrect password', js: true do
@@ -46,7 +46,7 @@ feature 'User log in' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile')
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq log_in_path
+      expect(page).to have_current_path log_in_path
     end
 
     scenario 'correct password but incorrect email address', js: true do
@@ -58,7 +58,7 @@ feature 'User log in' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile')
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq log_in_path
+      expect(page).to have_current_path log_in_path
     end
 
     scenario 'error alert will disappear when visiting subsequent page', js: true do
@@ -81,7 +81,7 @@ feature 'User log out' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile', href: user_path(user))
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -97,7 +97,7 @@ feature 'User log out' do
         expect(page).to have_link('Log in', href: log_in_path)
         expect(page).not_to have_link('Profile', href: user_path(user))
         expect(page).not_to have_link('Log out', href: log_out_path)
-        expect(current_path).to eq root_path
+        expect(page).to have_current_path root_path
       end
     end
   end
@@ -217,13 +217,13 @@ feature 'Friendly forwarding' do
       fill_in 'session_email',    with: user.email
       fill_in 'session_password', with: user.password
       click_button 'Log In'
-      expect(current_path).to eq edit_user_path(user)
+      expect(page).to have_current_path edit_user_path(user)
       click_link 'Log out'
       visit log_in_path
       fill_in 'session_email',    with: user.email
       fill_in 'session_password', with: user.password
       click_button 'Log In'
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
   end
 
@@ -235,13 +235,13 @@ feature 'Friendly forwarding' do
       click_button 'Log In'
       expect(page).to have_css '.alert-error'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
       click_link 'Log out'
       visit log_in_path
       fill_in 'session_email',    with: user.email
       fill_in 'session_password', with: user.password
       click_button 'Log In'
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
   end
 end

--- a/spec/features/users/users_new_create_spec.rb
+++ b/spec/features/users/users_new_create_spec.rb
@@ -25,7 +25,7 @@ feature 'User new/create' do
     scenario 'click on \'Add user\' link; display new user form', js: true do
       visit root_path
       click_link 'Add user'
-      expect(current_path).to eq new_user_path
+      expect(page).to have_current_path new_user_path
     end
   end
 
@@ -44,7 +44,7 @@ feature 'User new/create' do
       expect(page).to have_css '.alert-success'
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_css '.field_with_errors'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'user created; creator and updater associations (w/admin) created', js: true do
@@ -73,7 +73,7 @@ feature 'User new/create' do
       expect(page).to have_css '.alert-success'
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_css '.field_with_errors'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'user created; creator and updater associations (w/admin) created', js: true do
@@ -101,7 +101,7 @@ feature 'User new/create' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq users_path
+      expect(page).to have_current_path users_path
     end
 
     scenario 'invalid email', js: true do
@@ -111,7 +111,7 @@ feature 'User new/create' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq users_path
+      expect(page).to have_current_path users_path
     end
   end
 
@@ -137,7 +137,7 @@ feature 'User new/create' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile', href: user_path(new_user))
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'activation link not valid if invalid token given', js: true do
@@ -150,7 +150,7 @@ feature 'User new/create' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile', href: user_path(user))
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'activation link not valid if incorrect email given', js: true do
@@ -165,7 +165,7 @@ feature 'User new/create' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile', href: user_path(user))
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'activation link valid if valid token and correct email given', js: true do
@@ -178,7 +178,7 @@ feature 'User new/create' do
       expect(page).to have_link('Profile', href: user_path(user))
       expect(page).to have_link('Log out', href: log_out_path)
       expect(page).not_to have_link('Log in', href: log_in_path)
-      expect(current_path).to eq edit_account_activation_path(account_activation_token)
+      expect(page).to have_current_path edit_account_activation_path(account_activation_token, email: user.email)
     end
   end
 
@@ -197,7 +197,7 @@ feature 'User new/create' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq account_activation_path(@account_activation_token)
+      expect(page).to have_current_path account_activation_path(@account_activation_token)
     end
 
     scenario 'password cannot be set by entering password and confirmation that are too short', js: true do
@@ -207,7 +207,7 @@ feature 'User new/create' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq account_activation_path(@account_activation_token)
+      expect(page).to have_current_path account_activation_path(@account_activation_token)
     end
 
     scenario 'password cannot be set by entering non-matching password and confirmation', js: true do
@@ -217,7 +217,7 @@ feature 'User new/create' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq account_activation_path(@account_activation_token)
+      expect(page).to have_current_path account_activation_path(@account_activation_token)
     end
 
     scenario 'if password not set correctly existing creator and updater associations (w/admin) remain', js: true do
@@ -239,7 +239,7 @@ feature 'User new/create' do
       expect(page).to have_css '.alert-success'
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_css '.field_with_errors'
-      expect(current_path).to eq user_path(@new_user)
+      expect(page).to have_current_path user_path(@new_user)
     end
 
     scenario 'password is set; existing creator association (w/admin) remains and updater association (w/itself) updated', js: true do
@@ -275,7 +275,7 @@ feature 'User new/create' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile')
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq log_in_path
+      expect(page).to have_current_path log_in_path
       fill_in 'session_email',    with: user[:email]
       fill_in 'session_password', with: edit_user[:password]
       click_button 'Log In'
@@ -284,7 +284,7 @@ feature 'User new/create' do
       expect(page).to have_link('Profile', href: user_path(new_user))
       expect(page).to have_link('Log out', href: log_out_path)
       expect(page).not_to have_link('Log in', href: log_in_path)
-      expect(current_path).to eq user_path(new_user)
+      expect(page).to have_current_path user_path(new_user)
     end
   end
 end

--- a/spec/features/users/users_password_reset_spec.rb
+++ b/spec/features/users/users_password_reset_spec.rb
@@ -12,7 +12,7 @@ feature 'User password reset' do
       expect { click_button 'Submit' }.to change { ActionMailer::Base.deliveries.count }.by 0
       expect(page).to have_css '.alert-error'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq password_resets_path
+      expect(page).to have_current_path password_resets_path
     end
 
     scenario 'as unactivated user: redirect to home page with instructions to first activate account', js: true do
@@ -22,7 +22,7 @@ feature 'User password reset' do
       expect { click_button 'Submit' }.to change { ActionMailer::Base.deliveries.count }.by 0
       expect(page).to have_css '.alert-error'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'as activated user: redirect to home page with success message; password reset email sent', js: true do
@@ -32,7 +32,7 @@ feature 'User password reset' do
       expect { click_button 'Submit' }.to change { ActionMailer::Base.deliveries.count }.by 1
       expect(page).to have_css '.alert-success'
       expect(page).not_to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -46,31 +46,31 @@ feature 'User password reset' do
     scenario 'not valid if invalid token given', js: true do
       user_email = acquire_email_address @msg
       visit edit_password_reset_path('invalid-token', email: user_email)
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'not valid if invalid email given', js: true do
       visit edit_password_reset_path(@password_reset_token, email: 'incorrect-email')
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'valid if valid token and correct email given', js: true do
       user = click_resource_link @msg, 'password_reset'
       expect(find('#email', :visible => false).value).to eq user.email
-      expect(current_path).to eq edit_password_reset_path(@password_reset_token)
+      expect(page).to have_current_path edit_password_reset_path(@password_reset_token, email: user.email)
     end
 
     scenario 'redirects to home page if user not activated', js: true do
       user.update_attribute(:activated_at, nil)
       click_resource_link @msg, 'password_reset'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'redirects to link request page if token has expired', js: true do
       user.update_attribute(:reset_sent_at, 3.hours.ago)
       click_resource_link @msg, 'password_reset'
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq new_password_reset_path
+      expect(page).to have_current_path new_password_reset_path
     end
   end
 
@@ -89,7 +89,7 @@ feature 'User password reset' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq password_reset_path(@password_reset_token)
+      expect(page).to have_current_path password_reset_path(@password_reset_token)
     end
 
     scenario 'password cannot be reset by entering password and confirmation that are too short', js: true do
@@ -99,7 +99,7 @@ feature 'User password reset' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq password_reset_path(@password_reset_token)
+      expect(page).to have_current_path password_reset_path(@password_reset_token)
     end
 
     scenario 'password cannot be reset by entering non-matching password and confirmation', js: true do
@@ -109,7 +109,7 @@ feature 'User password reset' do
       expect(page).to have_css '.alert-error'
       expect(page).to have_css '.field_with_errors'
       expect(page).not_to have_css '.alert-success'
-      expect(current_path).to eq password_reset_path(@password_reset_token)
+      expect(page).to have_current_path password_reset_path(@password_reset_token)
     end
 
     scenario 'password is reset by entering valid password and confirmation', js: true do
@@ -119,7 +119,7 @@ feature 'User password reset' do
       expect(page).to have_css '.alert-success'
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_css '.field_with_errors'
-      expect(current_path).to eq user_path(@user)
+      expect(page).to have_current_path user_path(@user)
     end
 
     scenario 'after password is reset only new password can be used', js: true do
@@ -136,7 +136,7 @@ feature 'User password reset' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile')
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq log_in_path
+      expect(page).to have_current_path log_in_path
       fill_in 'session_email',    with: user.email
       fill_in 'session_password', with: 'new-password'
       click_button 'Log In'
@@ -145,7 +145,7 @@ feature 'User password reset' do
       expect(page).to have_link('Profile', href: user_path(user))
       expect(page).to have_link('Log out', href: log_out_path)
       expect(page).not_to have_link('Log in', href: log_in_path)
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
   end
 end

--- a/spec/features/users/users_show_spec.rb
+++ b/spec/features/users/users_show_spec.rb
@@ -15,7 +15,7 @@ feature 'User profile' do
       expect(page).not_to have_button('Edit Admin Status')
       expect(page).not_to have_button('Edit Suspension Status')
       expect(page).not_to have_button('Delete User')
-      expect(current_path).to eq user_path(super_admin_user)
+      expect(page).to have_current_path user_path(super_admin_user)
     end
 
     scenario 'viewing another super-admin user profile: show super-admin user profile page', js: true do
@@ -26,7 +26,7 @@ feature 'User profile' do
       expect(page).not_to have_button('Edit Admin Status')
       expect(page).not_to have_button('Edit Suspension Status')
       expect(page).not_to have_button('Delete User')
-      expect(current_path).to eq user_path(second_super_admin_user)
+      expect(page).to have_current_path user_path(second_super_admin_user)
     end
 
     scenario 'viewing admin user profile: show admin user profile page', js: true do
@@ -37,7 +37,7 @@ feature 'User profile' do
       expect(page).to have_button('Edit Admin Status')
       expect(page).to have_button('Edit Suspension Status')
       expect(page).to have_button('Delete User')
-      expect(current_path).to eq user_path(admin_user)
+      expect(page).to have_current_path user_path(admin_user)
     end
 
     scenario 'viewing non-admin user profile: show non-admin user profile page', js: true do
@@ -48,7 +48,7 @@ feature 'User profile' do
       expect(page).to have_button('Edit Admin Status')
       expect(page).to have_button('Edit Suspension Status')
       expect(page).not_to have_button('Edit User')
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
   end
 
@@ -66,7 +66,7 @@ feature 'User profile' do
       expect(page).not_to have_button('Edit Admin Status')
       expect(page).not_to have_button('Edit Suspension Status')
       expect(page).not_to have_button('Delete User')
-      expect(current_path).to eq user_path(super_admin_user)
+      expect(page).to have_current_path user_path(super_admin_user)
     end
 
     scenario 'viewing own user admin user profile: show own admin user profile page', js: true do
@@ -77,7 +77,7 @@ feature 'User profile' do
       expect(page).not_to have_button('Edit Admin Status')
       expect(page).not_to have_button('Edit Suspension Status')
       expect(page).to have_button('Delete User')
-      expect(current_path).to eq user_path(admin_user)
+      expect(page).to have_current_path user_path(admin_user)
     end
 
     scenario 'viewing another admin user profile: show admin user profile page', js: true do
@@ -88,7 +88,7 @@ feature 'User profile' do
       expect(page).not_to have_button('Edit Admin Status')
       expect(page).not_to have_button('Edit Suspension Status')
       expect(page).not_to have_button('Delete User')
-      expect(current_path).to eq user_path(second_admin_user)
+      expect(page).to have_current_path user_path(second_admin_user)
     end
 
     scenario 'viewing non-admin user profile: show non-admin user profile page', js: true do
@@ -99,7 +99,7 @@ feature 'User profile' do
       expect(page).not_to have_button('Edit Admin Status')
       expect(page).to have_button('Edit Suspension Status')
       expect(page).not_to have_button('Edit User')
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
   end
 
@@ -112,13 +112,13 @@ feature 'User profile' do
     scenario 'attempting to view super-admin user profile: redirect to home page', js: true do
       visit user_path(super_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempting to view admin user profile: redirect to home page', js: true do
       visit user_path(admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'viewing own non-admin user profile: show own non-admin user profile page', js: true do
@@ -129,13 +129,13 @@ feature 'User profile' do
       expect(page).not_to have_button('Edit Admin Status')
       expect(page).not_to have_button('Edit Suspension Status')
       expect(page).to have_button('Delete User')
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
 
     scenario 'attempting to view another non-admin user profile: redirect to home page', js: true do
       visit user_path(second_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -145,7 +145,7 @@ feature 'User profile' do
     scenario 'redirect to log in page', js: true do
       visit user_path(user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq log_in_path
+      expect(page).to have_current_path log_in_path
     end
   end
 end

--- a/spec/features/users/users_suspension_status_spec.rb
+++ b/spec/features/users/users_suspension_status_spec.rb
@@ -10,23 +10,23 @@ feature 'User edit/update suspension status' do
     scenario 'attempt edit self (super-admin user): fail and redirect to home page', js: true do
       visit edit_suspension_status_path(super_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit another super-admin user: fail and redirect to home page', js: true do
       visit edit_suspension_status_path(second_super_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit admin user: render admin user suspension status edit form', js: true do
       visit edit_suspension_status_path(admin_user)
-      expect(current_path).to eq edit_suspension_status_path(admin_user)
+      expect(page).to have_current_path edit_suspension_status_path(admin_user)
     end
 
     scenario 'attempt edit non-admin user: render non-admin user suspension status edit form', js: true do
       visit edit_suspension_status_path(user)
-      expect(current_path).to eq edit_suspension_status_path(user)
+      expect(page).to have_current_path edit_suspension_status_path(user)
     end
   end
 
@@ -39,24 +39,24 @@ feature 'User edit/update suspension status' do
     scenario 'attempt edit super-admin user: fail and redirect to home page', js: true do
       visit edit_suspension_status_path(super_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit self (admin user): fail and redirect to home page', js: true do
       visit edit_suspension_status_path(admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit another admin user: fail and redirect to home page', js: true do
       visit edit_suspension_status_path(second_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit non-admin user: fail and redirect to home page', js: true do
       visit edit_suspension_status_path(user)
-      expect(current_path).to eq edit_suspension_status_path(user)
+      expect(page).to have_current_path edit_suspension_status_path(user)
     end
   end
 
@@ -69,25 +69,25 @@ feature 'User edit/update suspension status' do
     scenario 'attempt edit super-admin user: fail and redirect to home page', js: true do
       visit edit_suspension_status_path(super_admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit admin user: fail and redirect to home page', js: true do
       visit edit_suspension_status_path(admin_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit self (non-admin user): fail and redirect to home page', js: true do
       visit edit_suspension_status_path(user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempt edit another non-admin user: fail and redirect to home page', js: true do
       visit edit_suspension_status_path(second_user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -97,7 +97,7 @@ feature 'User edit/update suspension status' do
     scenario 'fail and redirect to log in page', js: true do
       visit edit_suspension_status_path(user)
       expect(page).to have_css '.alert-error'
-      expect(current_path).to eq log_in_path
+      expect(page).to have_current_path log_in_path
     end
   end
 
@@ -108,7 +108,7 @@ feature 'User edit/update suspension status' do
     scenario 'click on \'Edit Suspension Status\' button on user profile page; display user edit form' do
       visit user_path(user)
       click_button 'Edit Suspension Status'
-      expect(current_path).to eq edit_suspension_status_path(user)
+      expect(page).to have_current_path edit_suspension_status_path(user)
     end
   end
 
@@ -126,7 +126,7 @@ feature 'User edit/update suspension status' do
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_css '.field_with_errors'
       expect(user.suspension).to be nil
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
       visit edit_suspension_status_path(user)
       check('status')
       click_button 'Update Suspension Status'
@@ -134,7 +134,7 @@ feature 'User edit/update suspension status' do
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_css '.field_with_errors'
       expect(user.reload.suspension).not_to be nil
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
       visit edit_suspension_status_path(user)
       uncheck('status')
       click_button 'Update Suspension Status'
@@ -142,7 +142,7 @@ feature 'User edit/update suspension status' do
       expect(page).not_to have_css '.alert-error'
       expect(page).not_to have_css '.field_with_errors'
       expect(user.reload.suspension).to be nil
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
 
     scenario 'assignor and assignee associations created/destroyed', js: true do
@@ -166,7 +166,7 @@ feature 'User edit/update suspension status' do
       expect(page).not_to have_link('Profile', href: user_path(user))
       expect(page).not_to have_link('Log out', href: log_out_path)
       expect(page).to have_link('Log in', href: log_in_path)
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
       log_in super_admin_user
       visit edit_suspension_status_path(user)
       uncheck('status')
@@ -177,7 +177,7 @@ feature 'User edit/update suspension status' do
       expect(page).to have_link('Profile', href: user_path(user))
       expect(page).to have_link('Log out', href: log_out_path)
       expect(page).not_to have_link('Log in', href: log_in_path)
-      expect(current_path).to eq user_path(user)
+      expect(page).to have_current_path user_path(user)
     end
   end
 
@@ -199,7 +199,7 @@ feature 'User edit/update suspension status' do
       expect(page).to have_link('Log in', href: log_in_path)
       expect(page).not_to have_link('Profile')
       expect(page).not_to have_link('Log out', href: log_out_path)
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 end


### PR DESCRIPTION
As per http://stackoverflow.com/questions/33054071/capybara-test-current-path-to-page-created-object:

`expect(current_path).to eq expected_path`
doesn't use Capybara's waiting behavior - which means since click_on is asynchronous (isn't waiting for anything on screen, or for the submit to complete) your test may be very flaky. You're much better off using

`expect(page).to have_current_path expected_path`
since that will use Capybara's waiting behavior while checking for the expected path.
